### PR TITLE
chore: change how we parse env variable for redis

### DIFF
--- a/app_env_var
+++ b/app_env_var
@@ -7,6 +7,5 @@ DB_PASSWORD="secret"
 DB_PORT="5432"
 DB_NAME="mydb"
 DB_SSL="disabled"
-RED_CONN_STRING="localhost:6379"
-RED_PASSWORD=""
+REDIS_URL="xxxx"
 SLACK_BOT_TOKEN='xxxxxx'

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	host := os.Getenv("DB_HOST")
 	password, port := os.Getenv("DB_PASSWORD"), os.Getenv("DB_PORT")
 	db_name, db_ssl := os.Getenv("DB_NAME"), os.Getenv("DB_SSL")
-	redConn, redPassword := os.Getenv("RED_CONN_STRING"), os.Getenv("RED_PASSWORD")
+	redConn := os.Getenv("REDIS_URL")
 	slackToken := os.Getenv("SLACK_BOT_TOKEN")
 
 	post, err := postgres.ConnectPostgres(url, password, port, host, db_name, user, db_ssl)
@@ -48,7 +48,7 @@ func main() {
 		panic(err)
 	}
 
-	reds, err := red.ConnectRedis(redConn, redPassword, 0)
+	reds, err := red.ConnectRedis(redConn)
 	if err != nil {
 		log.Printf("redis error: %v\n", err)
 		return

--- a/repository/redis/connec.go
+++ b/repository/redis/connec.go
@@ -12,16 +12,12 @@ type RedisConn struct {
 	RConn *redis.Client
 }
 
-func ConnectRedis(host, password string, db int) (*RedisConn, error) {
+func ConnectRedis(redisUrl string) (*RedisConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	client := redis.NewClient(&redis.Options{
-		Addr:     host,
-		Password: password,
-		DB:       db,
-	})
-
+	opt, _ := redis.ParseURL(redisUrl)
+	client := redis.NewClient(opt)
 	pong, err := client.Ping(ctx).Result()
 
 	if err != nil {


### PR DESCRIPTION
## Fix: Correctly parse Redis connection string from environment variable

This PR updates the logic for parsing the Redis connection string from the environment variable 